### PR TITLE
Fix conflicting flexbox css with oerpub styled content. Remove auto calc...

### DIFF
--- a/styles/workspace/content.less
+++ b/styles/workspace/content.less
@@ -3,8 +3,8 @@
 #content {
   overflow-y: auto;
   overflow-x: hidden;
-  -webkit-flex: 1 0 auto;
-  flex: 1 0 auto;
+  -webkit-flex: 1 0;
+  flex: 1 0;
   background-color: #ebebeb;
   padding: 2em;
 


### PR DESCRIPTION
This is a replacement pull request for https://github.com/oerpub/github-book/pull/2. It appears this one change is the only relevant change, the rest is already merged in.
## 

Things may break when there would be another right sided flexbox.
We do not have a right sided one so everything is ok for now.
