### PR TITLE
make editor panel not disappear on small monitors

### DIFF
--- a/styles/workspace/sidebar.less
+++ b/styles/workspace/sidebar.less
@@ -74,9 +74,12 @@
 
 #workspace-container {
   width: 100%;
+  min-width: 1500px;
 
   // workspace minimized
   &.workspace-minimized {
+    min-width: (1500-@aside-width+40);
+
     #menu-and-content {
       width: calc(~"100% - 350px");
     }
@@ -96,6 +99,8 @@
 
   // sidebar minimized (#sidebar is the table of contents
   &.sidebar-minimized {
+    min-width: (1500-@aside-width+40);
+
     #menu-and-content {
       width: calc(~"100% - 350px");
     }
@@ -114,8 +119,10 @@
     }
   }
 
-  // workspace minimized
+  // workspace and sidebar minimized
   &.workspace-minimized.sidebar-minimized {
+    min-width: (1500-@aside-width*2+80);
+
     #menu-and-content {
       width: calc(~"100% - 80px");
     }

--- a/styles/workspace/workspace.less
+++ b/styles/workspace/workspace.less
@@ -35,7 +35,8 @@ html, body {
 #container {
   -webkit-box-orient: horizontal;
   box-orient: horizontal;
-  overflow: hidden;
+  overflow-y: hidden;
+  overflow-x: auto;
 }
 
 // Hide the floating toolbar


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/57874740

horizontal scrollbar will show up if the window is too small to render the editor properly.
