### PR TITLE
improve header styling

### DIFF
--- a/styles/workspace/oerpub-content.less
+++ b/styles/workspace/oerpub-content.less
@@ -3,30 +3,27 @@
 #content {
 
   .layout-root {
-    h1 {
-      color:#336699;
-      height: 30px;
-      padding:0 0 .1em;
-      border:0 solid #336699;
-      border-bottom-width:1px;
-      border-right-width:1px;
-      font-weight:bold;
-      font-size:1.5em;
-      letter-spacing:-1px;
-      line-height:1.5em;
+    h1, h2, h3, h4, h5, h6 {
+      color: #336699;
+      padding: 0;
+      font-weight: bold;
+      font-size: 1.7em;
+      letter-spacing: -1px;
+      margin: 0 0 10px; /* i.e. same as paragraphs */
+      line-height: normal;
+      height: auto;
     }
 
     h2, h3, h4, h5, h6 {
-      color:#336699;
-      padding:0 0 .1em;
-      border:0 solid #336699;
-      border-bottom-width:1px;
-      border-right-width:1px;
-      font-weight:bold;
-      font-size:1em;
-      margin:0;
-      letter-spacing:-1px;
-      line-height:1.5em;
+      letter-spacing: normal;
+      font-size: 1em;
+    }
+
+    h2 { 
+      font-size: 1.3em;
+    }
+    h3{
+      font-size: 1.05em;
     }
 
     a {


### PR DESCRIPTION
Remove the borders, use better sizes, don't let letter-spacing inherit past h1, use same margins as paragraphs.

Forthcoming (though I think relatively nondependent) commit coming on Aloha-Editor
