### PR TITLE
Firefox title fix

### DIFF
--- a/scripts/gh-book/opf-file.coffee
+++ b/scripts/gh-book/opf-file.coffee
@@ -324,7 +324,10 @@ define [
       # For the structure of the TOC file see `OPF_TEMPLATE`
       bookId = @$xml.find("##{@$xml.get 'unique-identifier'}").text()
 
-      title = @$xml.find('title').text()
+      # Explicitly use querySelectorAll, because firefox fails to find the
+      # title if you just use jQuery.find().
+      titles = @$xml[0].querySelectorAll('title')
+      title = titles.length and $(titles[0]).text() or ''
 
       # The manifest contains all the items in the spine
       # but the spine element says which order they are in

--- a/scripts/gh-book/opf-file.coffee
+++ b/scripts/gh-book/opf-file.coffee
@@ -322,7 +322,16 @@ define [
       return model.trigger 'error', 'INVALID_OPF' if not @$xml[0]
 
       # For the structure of the TOC file see `OPF_TEMPLATE`
-      bookId = @$xml.find("##{@$xml.get 'unique-identifier'}").text()
+      # An epub must contain an IDREF to the dublincore element that has the
+      # identification information. The `identifer` fallback is there to handle
+      # books created while a misspelling was in place.
+      IdAttr = @$xml[0].firstChild.getAttribute('unique-identifier') or
+        @$xml[0].firstChild.getAttribute('unique-identifer')
+
+      # Use querySelectorAll (because firefox breaks with jquery) to find the
+      # value of the referenced unique identifier.
+      bookIds = @$xml[0].querySelectorAll("##{IdAttr}")
+      bookId = bookIds.length and $(bookIds[0]).text() or ''
 
       # Explicitly use querySelectorAll, because firefox fails to find the
       # title if you just use jQuery.find().

--- a/templates/gh-book/defaults/opf.html
+++ b/templates/gh-book/defaults/opf.html
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifer="uid">
+<package xmlns="http://www.idpf.org/2007/opf" version="3.0" unique-identifier="uid">
   <metadata xmlns:dc="http://purl.org/dc/elements/1.1/">
     <dc:identifier id="uid"></dc:identifier>
     <dc:title>{{title}}</dc:title>


### PR DESCRIPTION
For some reason the document fragment that represents the opf file, when searched with jquery, doesn't work at all. I suspect it might be some namespace issue, because it seems okay on non-namespaced nodes. Not even the XSL/XPath machinery worked in firefox, even though it all worked flawlessly in Chrome. In the end I found that  querySelectorAll works, so I fixed both the title and bookid to use that instead.

Also fixed a spelling mistake in the opf file. This unfortunately means we generated books that aren't compliant, as they don't have a unique-identifier attribute on the package tag in the opf file.
