### PR TITLE
Migration improvements

### DIFF
--- a/docs/migration-framework.md
+++ b/docs/migration-framework.md
@@ -1,0 +1,71 @@
+# Migration Framework
+
+The purpose of the migration framework is to easily create tasks by which you
+can modify the content of a book in bulk.
+
+## Components
+
+The migration framework consists of a view implemented in
+`scripts/gh-book/migration.coffee`, some utility and helper functions in
+`scripts/gh-book/migration-utils.coffee`, and migration tasks in
+`scripts/migrations`.
+
+## Invoking a migration task
+
+Once you have a book loaded, the edit view will be open on the first module in
+that book, eg:
+
+    http://localhost:8080/#repo/shelf/book/edit/1.html|toc.opf
+
+Modify the url so as to invoke the migration view, and pass a migration task
+to run, for example to remove captions from tables:
+
+    http://localhost:8080/#repo/shelf/book/migrate/tables
+
+## Creating your own migration task
+
+Create a coffeescript file in `scripts/migrations`. This script should use
+require.js to define and return a single callable/function. This function
+itself takes a single parameter, a module. It should return a promise.
+
+The migration framework will iterate through all modules in the book and pass
+them to your migration function one by one. It is your own responsibility to
+check if the passed module is of the right type. This allows the writing of
+migration tasks for any type of module, by delegating the module selection
+logic to the task itself.
+
+If there is some problem with the migration of the module, the promise should
+be rejected. Otherwise the promise should be resolved with another parameter,
+which is either 'skipped' or 'completed'. You should pass 'skipped' if the
+passed module is not of a type you want to migrate. Upon successful migration,
+resolve the promise with the 'completed' parameter.
+
+## Helper utils
+
+Presently there is only one util: A factory function that creates simple
+migrations specifically for xhtml modules.
+
+### Xhtml helper
+
+Because the majority of migrations are expected to be changes to the xhtml
+content of a book, you will find in `scripts/gh-book/migration-utils.coffee`
+a factory method that uses a callback to create a migration function. This
+utility will automatically skip non-xhtml modules, fetch the rest, parse them
+and construct a document object. It will then call the provided callback
+function and pass the jquery-wrapped document as a parameter. The job of the
+callback is to change the passed jquery object, and then return true if any
+changes were made, false otherwise.
+
+This allows very simple xhtml migrations to be written, for example:
+
+    define ['cs!gh-book/migration-utils'], (MigrationUtils) ->
+      return MigrationUtils.migrateXhtmlFile ($body) ->
+        # Add listing class to tables
+        $tables = $body.find('table')
+        if $tables.length
+          $tables.addClass('listing')
+          return true
+        return false
+
+## Existing migrations
+* tables: Scans all xhtml documents and remove captions from tables.

--- a/docs/migration-framework.md
+++ b/docs/migration-framework.md
@@ -69,3 +69,5 @@ This allows very simple xhtml migrations to be written, for example:
 
 ## Existing migrations
 * tables: Scans all xhtml documents and remove captions from tables.
+* head: Looks for documents with `<head>undefined</head>`, caused by another
+  bug in the code, and remove it.

--- a/scripts/app.coffee
+++ b/scripts/app.coffee
@@ -288,7 +288,7 @@ define [
 
           goMigrate: (repoUser, repoName, branch, task) ->
             @_loadFirst(repoUser, repoName, branch).done () =>
-              require ['cs!gh-book/migration', 'cs!views/layouts/workspace/sidebar', 'cs!gh-book/opf-file'], (MigrationView, SidebarView, OpfFile) ->
+              require ['cs!gh-book/migration', 'cs!views/layouts/workspace/table-of-contents', 'cs!gh-book/opf-file'], (MigrationView, TocView, OpfFile) ->
                 # Find the first opf file.
                 opf = allContent.findWhere({mediaType: OpfFile.prototype.mediaType})
 
@@ -299,10 +299,10 @@ define [
                 allContent.load()
                 .fail(() => alert 'Problem loading workspace. Please refresh and try again')
                 .done () =>
-                  controller._showWorkspacePane(SidebarView)
+                  controller._showWorkspacePane(TocView)
 
                   if opf
-                    contextView = new SidebarView
+                    contextView = new TocView
                       model: opf
                     controller.layout.sidebar.show(contextView)
                     contextView.maximize()

--- a/scripts/gh-book/gh-book.less
+++ b/scripts/gh-book/gh-book.less
@@ -191,21 +191,26 @@ nav#workspace-sidebar-toc{
     font-family: FontAwesome;
     font-size: 14px;
   }
+  span.migration-result:before {
+    content: "\f141";
+    font-family: FontAwesome;
+    font-size: 14px;
+  }
   p.success {
     span:before {
-      content:  "\f046";
+      content:  "\f00c";
     }
     &.completed {
       background-color: #DEFF99;
     }
     &.skipped {
-      background-color: #FFFFDD;
+      background-color: #FFFFFF;
     }
   }
   p.fail {
     background-color: #EEA6A6;
     span:before {
-      content:  "\f096";
+      content:  "\f00d";
     }
   }
 }

--- a/scripts/gh-book/gh-book.less
+++ b/scripts/gh-book/gh-book.less
@@ -213,4 +213,8 @@ nav#workspace-sidebar-toc{
       content:  "\f00d";
     }
   }
+  p.migration-complete {
+    font-weight: bold;
+    font-size: 120%;
+  }
 }

--- a/scripts/gh-book/gh-book.less
+++ b/scripts/gh-book/gh-book.less
@@ -195,8 +195,15 @@ nav#workspace-sidebar-toc{
     span:before {
       content:  "\f046";
     }
+    &.completed {
+      background-color: #DEFF99;
+    }
+    &.skipped {
+      background-color: #FFFFDD;
+    }
   }
   p.fail {
+    background-color: #EEA6A6;
     span:before {
       content:  "\f096";
     }

--- a/scripts/gh-book/migration-utils.coffee
+++ b/scripts/gh-book/migration-utils.coffee
@@ -32,10 +32,10 @@ define ['jquery', 'gh-book/xhtml-file'], ($, XhtmlFile) ->
             model.set
                 body: serializer.serializeToString(doc)
 
-          promise.resolve()
+          promise.resolve("completed")
         .fail () ->
           promise.reject()
       else
         # Not an xhtml module, We're done.
-        promise.resolve()
+        promise.resolve("skipped")
       return promise

--- a/scripts/gh-book/migration-utils.coffee
+++ b/scripts/gh-book/migration-utils.coffee
@@ -20,8 +20,9 @@ define ['jquery', 'gh-book/xhtml-file'], ($, XhtmlFile) ->
 
           # DOMParser does not properly throw an exception, but at least chrome
           # and firefox adds a parsererror element to the page.
-          if $body.find('parsererror').length
-            promise.reject()
+          err = $body.find('parsererror')
+          if err.length
+            promise.reject(err.find('div').html())
             return
 
           # Call callback here, pass the jquery wrapped doc. Callback modified

--- a/scripts/gh-book/migration.coffee
+++ b/scripts/gh-book/migration.coffee
@@ -18,6 +18,8 @@ define [
       $loadingText = @$el.find('#loading-text')
       $log = @$el.find('#migrationlog')
 
+      $viewport = @$el.parent().parent()
+
       if @task
         $loadingText.html("Running migration for #{@task}")
         # Check task for funny characters, because we're about to feed it
@@ -35,9 +37,13 @@ define [
                 return if not queue.length
                 model = queue.shift()
 
+                # Are we scrolled to the bottom? Used later to avoid jumping
+                # to the end while the user is trying to scroll elsewhere.
+                scrollBottom = $viewport[0].offsetHeight + $viewport[0].scrollTop >= $viewport[0].scrollHeight
+
                 # migrate the module. Pull in the requested task and pass
                 # the module to it.
-                $line = $("<p>Migrating #{model.id} ... <span> </span></p>")
+                $line = $("<p>Migrating #{model.id} <span class=\"migration-result\"> </span></p>")
                 $log.append($line)
                 resolve = (cls, tt) ->
                   migrated++
@@ -52,6 +58,11 @@ define [
                       placement: 'right'
                       trigger: 'hover'
                 resolve = resolve.bind($line)
+
+                # Scroll window to the current log line, but only if it's
+                # scrolled to the bottom already. This allows a user to scroll
+                # up without interference.
+                $viewport.scrollTop($viewport[0].scrollHeight) if scrollBottom
 
                 f(model).done (msg) ->
                   c = 'success'

--- a/scripts/gh-book/migration.coffee
+++ b/scripts/gh-book/migration.coffee
@@ -34,7 +34,10 @@ define [
             # migrate any type of content.
             require ["cs!migrations/#{@task}"], (f) ->
               migrateModels = (queue) ->
-                return if not queue.length
+                if not queue.length
+                  $log.append("<p class=\"migration-complete\">Migration completed at #{(new Date()).toLocaleString()}</p>")
+                  return
+
                 model = queue.shift()
 
                 # Are we scrolled to the bottom? Used later to avoid jumping

--- a/scripts/gh-book/migration.coffee
+++ b/scripts/gh-book/migration.coffee
@@ -39,17 +39,24 @@ define [
                 # the module to it.
                 $line = $("<p>Migrating #{model.id} ... <span> </span></p>")
                 $log.append($line)
-                resolve = (cls) ->
+                resolve = (cls, tt) ->
                   migrated++
                   percentage = 100 * migrated / total
                   $loadingBar.attr('style', "width: #{percentage}%;")
                   @addClass(cls)
+                  if tt
+                    @find('span').popover
+                      html: true
+                      title: 'Error'
+                      content: tt
+                      placement: 'right'
+                      trigger: 'hover'
                 resolve = resolve.bind($line)
 
                 f(model).done () ->
                   resolve('success')
-                .fail () ->
-                  resolve('fail')
+                .fail (err) ->
+                  resolve('fail', err)
                   $loadingBar.addClass('bar-danger')
                 .always () ->
                   migrateModels(queue)

--- a/scripts/gh-book/migration.coffee
+++ b/scripts/gh-book/migration.coffee
@@ -47,14 +47,16 @@ define [
                   if tt
                     @find('span').popover
                       html: true
-                      title: 'Error'
+                      title: 'Status'
                       content: tt
                       placement: 'right'
                       trigger: 'hover'
                 resolve = resolve.bind($line)
 
-                f(model).done () ->
-                  resolve('success')
+                f(model).done (msg) ->
+                  c = 'success'
+                  c += ' ' + msg if msg
+                  resolve(c, msg)
                 .fail (err) ->
                   resolve('fail', err)
                   $loadingBar.addClass('bar-danger')


### PR DESCRIPTION
Care is taken to let the progress bar run all the way, in the past failures caused it to stop short.

Since we'll mostly be doing xhtml migrations, this adds a utils module with a factory method that creates migrations for xhtml modules, so you only have to write a bit of jquery code to transform the passed $body object.

If anything fails, the migration continues, but the progress bar turns red to visually indicate that something was wrong.

Errors in migration is shown in a popover.

This supersedes #135.
