### PR TITLE
Fix namespace error message

### DIFF
--- a/scripts/gh-book/xhtml-file.coffee
+++ b/scripts/gh-book/xhtml-file.coffee
@@ -216,9 +216,19 @@ define [
 
       @loadImages($html)
 
+      # Chrome is so concerned that we might lose the namespace that it adds
+      # it to every node whenever we serialize a portion of the tree.
+      # Therefore we cannot use innerHTML and we cannot separately serialize
+      # the head and the body. We instead serialize the whole thing and
+      # cut out the bit we need, which is safe because we know we're working
+      # with valid xml.
+      s = (new XMLSerializer()).serializeToString(doc)
+      head = s.split(/<\/?head[^>]*>/)[1]
+      body = s.split(/<\/?body[^>]*>/)[1]
+
       attributes =
-        head: $head[0]?.innerHTML?.trim() or ''
-        body: $body[0]?.innerHTML?.trim() or ''
+        head: head?.trim() or ''
+        body: body?.trim() or ''
 
       # Set the title that is in the `<head>`
       # TODO: Re-enable after the sprint


### PR DESCRIPTION
The problem snuck in after I fixed the double-body problem some time ago. By using the innerHTML of the body instead of serializing the body, I ended up with a xmlns on every top level element inside the body.

When you hit enter in Aloha, it makes a copy of whatever element it's in. It also copies all the attributes. It didn't like copying xmlns, hence the error message.

This fixes the problem using somewhat of a sledgehammer approach. It parses the body/head out using regex. Normally that's a bad idea for html, but here we use fresh html from XMLSerializer, so it should be safe.
